### PR TITLE
Do not declare qHash for QJson classes on Qt >= 5.12

### DIFF
--- a/QtJsonSchema/src/hashfunctions.cpp
+++ b/QtJsonSchema/src/hashfunctions.cpp
@@ -1,6 +1,7 @@
 #include "hashfunctions.h"
 #include "pointer/jsonpointer.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
 uint qHash(const QJsonValue& json, uint seed)
 {
   switch (json.type()) {
@@ -28,6 +29,7 @@ uint qHash(const QJsonObject& object, uint seed)
 {
   return std::accumulate(object.constBegin(), object.constEnd(), seed, HashCombine());
 }
+#endif
 
 uint qHash(const JsonPointer& ptr, uint seed)
 {

--- a/QtJsonSchema/src/hashfunctions.h
+++ b/QtJsonSchema/src/hashfunctions.h
@@ -11,9 +11,12 @@ struct HashCombine {
   { return seed ^ (qHash(t) + 0x9e3779b9 + (seed << 6) + (seed >> 2)) ; }
 };
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
 uint qHash(const QJsonValue& json, uint seed = 0);
 uint qHash(const QJsonArray& array, uint seed = 0);
 uint qHash(const QJsonObject& object, uint seed = 0);
+#endif
+
 uint qHash(const JsonPointer& ptr, uint seed = 0);
 
 #endif // HASHFUNCTIONS_H


### PR DESCRIPTION
Hi, 

when compiling with Qt 5.12, the qHash functions for QJson classes are already defined in the Qt framework itself. This pull request fixes the compilation for Qt 5.12

Cheers